### PR TITLE
ci: use Volta

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,23 @@
+name: Set up Node.js and Yarn
+description: Use Volta to set up pinned versions of Node.js and Yarn. Cache the Yarn cache directory and install dependencies.
+author: LayZeeDK
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js and Yarn
+      uses: volta-cli/action@v1
+    - name: Get Yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Cache Yarn cache directory
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: Install package dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile --no-interactive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-      - name: Install package dependencies
-        run: yarn install
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Lint
         run: yarn lint
@@ -58,13 +53,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-      - name: Install package dependencies
-        run: yarn install
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Test
         run: yarn test
@@ -76,13 +66,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-      - name: Install package dependencies
-        run: yarn install
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Build
         run: yarn build

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -36,13 +36,8 @@ jobs:
       - name: Check out head branch
         run: git checkout -
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          cache: yarn
-          node-version-file: .nvmrc
-      - name: Install package dependencies
-        run: yarn install
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/setup-node
 
       - name: Migrate Nx workspace
         run: yarn nx run tools:migrate-nx


### PR DESCRIPTION
Use Volta to manage Node.js and Yarn to be able to use the latest Yarn Classic patch.