### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.0.2
+## 0.0.2 (2021-11-20)
 
 ### Refactorings
 
 - Encapsulate members inherited from `ComponentStore`
 
-## 0.0.1
+## 0.0.1 (2021-11-20)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,16 +109,17 @@ export class AppModule {}
 ```typescript
 // hero.service.ts
 // (...)
-import { RouterStore } from "@ngworker/router-component-store";
+import { RouterStore } from '@ngworker/router-component-store';
 
 @Injectable({
-  providedIn: "root",
+  providedIn: 'root',
 })
 export class HeroService {
-  activeHeroId$: Observable<string> = this.routerStore.selectQueryParam("id");
+  activeHeroId$: Observable<string> = this.routerStore.selectQueryParam('id');
 
   constructor(private routerStore: RouterStore) {}
 }
+```
 
 ## 0.0.2 (2021-11-20)
 
@@ -132,4 +133,3 @@ export class HeroService {
 
 - add `GlobalRouterStore`
 - add `LocalRouterStore`
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,121 @@
 # Router Component Store changelog
 
+## 0.1.0 (2022-10-20)
+
+## Features
+
+- Add `RouterStore`
+- Remove `LocalRouterStore`
+- Add `provideLocalRouterStore`
+- Remove `GlobalRouterStore`
+- Add `provideGlobalRouterStore`
+
+## **BREAKING CHANGES**
+
+### Require RxJS 7.2
+
+We now require at least RxJS version 7.2 to import operators from the primary entry point of the `rxjs` package.
+
+### LocalRouterStore is removed
+
+`LocalRouterStore` is replaced by `RouterStore` and `provideLocalRouterStore`.
+
+#### Migration
+
+Use `provideLocalRouterStore()` as component-level provider and inject `RouterStore` instead of `LocalRouterStore`.
+
+Before:
+
+```typescript
+// hero-detail.component.ts
+// (...)
+import { LocalRouterStore } from '@ngworker/router-component-store';
+
+@Component({
+  // (...)
+  providers: [LocalRouterStore],
+})
+export class HeroDetailComponent {
+  heroId$: Observable<string> = this.routerStore.selectQueryParam('id');
+
+  constructor(private routerStore: LocalRouterStore) {}
+}
+```
+
+After:
+
+```typescript
+// hero-detail.component.ts
+// (...)
+import {
+  provideLocalRouterStore,
+  RouterStore,
+} from '@ngworker/router-component-store';
+
+@Component({
+  // (...)
+  providers: [provideLocalRouterStore()],
+})
+export class HeroDetailComponent {
+  heroId$: Observable<string> = this.routerStore.selectQueryParam('id');
+
+  constructor(private routerStore: RouterStore) {}
+}
+```
+
+### GlobalRouterStore is removed
+
+`GlobalRouterStore` is replaced by `RouterStore` and `provideGlobalRouterStore`.
+
+#### Migration
+
+Add `provideGlobalRouterStore()` to your root environment injector and inject `RouterStore` instead of `GlobalRouterStore`.
+
+Before:
+
+```typescript
+// hero.service.ts
+// (...)
+import { GlobalRouterStore } from '@ngworker/router-component-store';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HeroService {
+  activeHeroId$: Observable<string> = this.routerStore.selectQueryParam('id');
+
+  constructor(private routerStore: GlobalRouterStore) {}
+}
+```
+
+After:
+
+```typescript
+// app.module.ts
+// (...)
+import { provideGlobalRouterStore } from '@ngworker/router-component-store';
+
+@NgModule({
+  // (...)
+  providers: [provideGlobalRouterStore()],
+})
+export class AppModule {}
+```
+
+```typescript
+// hero.service.ts
+// (...)
+import { RouterStore } from "@ngworker/router-component-store";
+
+@Injectable({
+  providedIn: "root",
+})
+export class HeroService {
+  activeHeroId$: Observable<string> = this.routerStore.selectQueryParam("id");
+
+  constructor(private routerStore: RouterStore) {}
+}
+
 ## 0.0.2 (2021-11-20)
 
 ### Refactorings
@@ -12,3 +128,4 @@
 
 - add `GlobalRouterStore`
 - add `LocalRouterStore`
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Remove `GlobalRouterStore`
 - Add `provideGlobalRouterStore`
 
+## Bug fixes
+
+- Fix [#272](https://github.com/ngworker/router-component-store/issues/272): Class constructor ComponentStore cannot be invoked without 'new'
+
 ## **BREAKING CHANGES**
 
 ### Require RxJS 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# Router Component Store changelog
 
 ## 0.0.2 (2021-11-20)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# @ngworker/router-component-store
+# Router Component Store
 
-Angular Router-connecting NgRx component stores.
+[`@ngworker/router-component-store`](https://www.npmjs.com/package/@ngworker/router-component-store)
+
+An Angular Router-connecting NgRx component store.
 
 ## Compatibility
 

--- a/packages/router-component-store/ng-package.json
+++ b/packages/router-component-store/ng-package.json
@@ -2,6 +2,9 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/packages/router-component-store",
   "lib": {
-    "entryFile": "src/index.ts"
+    "entryFile": "src/index.ts",
+    "umdModuleIds": {
+      "@ngrx/component-store": "ngrx.componentStore"
+    }
   }
 }

--- a/packages/router-component-store/ng-package.json
+++ b/packages/router-component-store/ng-package.json
@@ -3,6 +3,7 @@
   "dest": "../../dist/packages/router-component-store",
   "lib": {
     "entryFile": "src/index.ts",
+    "umdId": "ngworker.routerComponentStore",
     "umdModuleIds": {
       "@ngrx/component-store": "ngrx.componentStore"
     }

--- a/packages/router-component-store/package.json
+++ b/packages/router-component-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngworker/router-component-store",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Angular Router-connecting NgRx component stores.",
   "license": "MIT",
   "peerDependencies": {

--- a/packages/router-component-store/package.json
+++ b/packages/router-component-store/package.json
@@ -7,7 +7,7 @@
     "@angular/core": "^12.2.0",
     "@angular/router": "^12.2.0",
     "@ngrx/component-store": "^12.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Data, Params, Router } from '@angular/router';
 import { ComponentStore } from '@ngrx/component-store';
 import { map, Observable } from 'rxjs';
@@ -55,7 +55,10 @@ export class GlobalRouterStore
     (routerState) => routerState.url
   );
 
-  constructor(router: Router, serializer: MinimalRouterStateSerializer) {
+  constructor(
+    @Inject(Router) router: Router,
+    serializer: MinimalRouterStateSerializer
+  ) {
     super({
       routerState: serializer.serialize(router.routerState.snapshot),
     });

--- a/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { ActivatedRoute, Data, Params, Router } from '@angular/router';
 import { ComponentStore } from '@ngrx/component-store';
 import { map, Observable } from 'rxjs';
@@ -46,8 +46,8 @@ export class LocalRouterStore
   );
 
   constructor(
-    route: ActivatedRoute,
-    router: Router,
+    @Inject(ActivatedRoute) route: ActivatedRoute,
+    @Inject(Router) router: Router,
     serializer: MinimalRouterStateSerializer
   ) {
     super({


### PR DESCRIPTION
# Release
- Update changelog
- Bump major prerelease version

# Build
- Require RxJS ^7.2.0 peer dependency
- Add global UMD ID to prevent dash usage
- Add external UMD module ID for `@ngrx/component-store`
- Decorate `Router` and `ActivatedRoute` dependencies with `Inject` to remove build warnings about unused imports