### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,10 +11,14 @@ runs:
       id: yarn-cache-dir-path
       shell: bash
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+    - name: Get Node.js version
+      id: node-version
+      shell: bash
+      run: echo "version=$(node -v)" >> $GITHUB_OUTPUT
     - name: Cache Yarn cache directory
       uses: actions/cache@v3
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        key: ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-yarn-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-yarn-
+          ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-yarn-

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -14,11 +14,11 @@ runs:
     - name: Get Node.js version
       id: node-version
       shell: bash
-      run: echo "version=$(node -v)" >> $GITHUB_OUTPUT
+      run: echo "major=$(node -v | sed 's/v\([0-9]*\).*/\1/')" >> $GITHUB_OUTPUT
     - name: Cache Yarn cache directory
       uses: actions/cache@v3
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-yarn-${{ hashFiles('yarn.lock') }}
+        key: ${{ runner.os }}-node-${{ steps.node-version.outputs.major }}-yarn-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-yarn-
+          ${{ runner.os }}-node-${{ steps.node-version.outputs.major }}-yarn-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Build
         run: yarn build
+      - name: Bundle readme
+        run: cp README.md dist/packages/router-component-store/
 
       - name: '[Merge] Upload package bundle'
         if: ${{ env.is-merge-to-main == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Router Component Store changelog
 
-## 0.1.0 (2022-10-20)
+## 0.1.1 (2022-10-21)
 
-## Features
+### Features
 
 - Add `RouterStore`
 - Remove `LocalRouterStore`
@@ -10,21 +10,21 @@
 - Remove `GlobalRouterStore`
 - Add `provideGlobalRouterStore`
 
-## Bug fixes
+### Bug fixes
 
 - Fix [#272](https://github.com/ngworker/router-component-store/issues/272): Class constructor ComponentStore cannot be invoked without 'new'
 
-## **BREAKING CHANGES**
+### **BREAKING CHANGES**
 
-### Require RxJS 7.2
+#### Require RxJS 7.2
 
 We now require at least RxJS version 7.2 to import operators from the primary entry point of the `rxjs` package.
 
-### LocalRouterStore is removed
+#### LocalRouterStore is removed
 
 `LocalRouterStore` is replaced by `RouterStore` and `provideLocalRouterStore`.
 
-#### Migration
+##### Migration
 
 Use `provideLocalRouterStore()` as component-level provider and inject `RouterStore` instead of `LocalRouterStore`.
 
@@ -67,11 +67,11 @@ export class HeroDetailComponent {
 }
 ```
 
-### GlobalRouterStore is removed
+#### GlobalRouterStore is removed
 
 `GlobalRouterStore` is replaced by `RouterStore` and `provideGlobalRouterStore`.
 
-#### Migration
+##### Migration
 
 Add `provideGlobalRouterStore()` to your root environment injector and inject `RouterStore` instead of `GlobalRouterStore`.
 

--- a/packages/router-component-store/package.json
+++ b/packages/router-component-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngworker/router-component-store",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Angular Router-connecting NgRx component stores.",
   "license": "MIT",
   "peerDependencies": {
@@ -17,8 +17,7 @@
     "router",
     "component-store",
     "ngworker",
-    "angular",
-    "angular2"
+    "angular"
   ],
   "author": {
     "name": "Lars Gyrup Brink Nielsen",
@@ -28,8 +27,7 @@
   "contributors": [],
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
-    "tag": "unknown"
+    "registry": "https://registry.npmjs.org/"
   },
   "bugs": {
     "url": "https://github.com/ngworker/router-component-store/issue"


### PR DESCRIPTION
I accidentally unpublished 0.1.0 from npm because it didn't contain a readme file.

# Build
- Bump minor prerelease version
- Correct changelog
- Bundle readme file
- Remove `unknown` npm tag

# CI
- Add major Node.js version to cache key