### PR TITLE
docs: fix API formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Published with partial Ivy compilation.
 
 A `RouterStore` service has the following public properties:
 
-| API                                                              | Description                                |
-| ---------------------------------------------------------------- | ------------------------------------------ |
-| currentRoute$: Observable<MinimalActivatedRouteSnapshot>         | Select the current route.                  |
-| fragment$: Observable<string \| null>                            | Select the current route fragment.         |
-| queryParams$: Observable<Params>                                 | Select the current route query parameters. |
-| routeData$: Observable<Data>                                     | Select the current route data.             |
-| routeParams$: Observable<Params>                                 | Select the current route parameters.       |
-| url$: Observable<string>                                         | Select the current URL.                    |
-| selectQueryParam(param: string): Observable<string \| undefined> | Select the specified query parameter.      |
-| selectRouteParam(param: string): Observable<string \| undefined> | Select the specified route parameter.      |
+| API                                                                | Description                                |
+| ------------------------------------------------------------------ | ------------------------------------------ |
+| `currentRoute$: Observable<MinimalActivatedRouteSnapshot>`         | Select the current route.                  |
+| `fragment$: Observable<string \| null>`                            | Select the current route fragment.         |
+| `queryParams$: Observable<Params>`                                 | Select the current route query parameters. |
+| `routeData$: Observable<Data>`                                     | Select the current route data.             |
+| `routeParams$: Observable<Params>`                                 | Select the current route parameters.       |
+| `url$: Observable<string>`                                         | Select the current URL.                    |
+| `selectQueryParam(param: string): Observable<string \| undefined>` | Select the specified query parameter.      |
+| `selectRouteParam(param: string): Observable<string \| undefined>` | Select the specified route parameter.      |
 
 A `RouterStore` service is provided by using either `provideGlobalRouterStore` or `provideLocalRouterStore`.
 


### PR DESCRIPTION
Display the observable type parameters when the API Markdown table is rendered.