### PR TITLE
feat!: return `Provider[]` from provider factories

### DIFF
--- a/packages/router-component-store/src/lib/global-router-store/provide-global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/provide-global-router-store.ts
@@ -32,11 +32,11 @@ import { GlobalRouterStore } from './global-router-store';
  * })
  * export class AppModule {}
  */
-export function provideGlobalRouterStore(): Provider {
+export function provideGlobalRouterStore(): Provider[] {
   const globalRouterStoreProvider: ClassProvider = {
     provide: RouterStore,
     useClass: GlobalRouterStore,
   };
 
-  return globalRouterStoreProvider;
+  return [globalRouterStoreProvider];
 }

--- a/packages/router-component-store/src/lib/local-router-store/provide-local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/provide-local-router-store.ts
@@ -31,11 +31,11 @@ import { LocalRouterStore } from './local-router-store';
  *   heroId$: Observable<string | undefined> = this.#routerStore.selectQueryParam('id');
  * }
  */
-export function provideLocalRouterStore(): Provider {
+export function provideLocalRouterStore(): Provider[] {
   const localRouterStoreProvider: ClassProvider = {
     provide: RouterStore,
     useClass: LocalRouterStore,
   };
 
-  return localRouterStoreProvider;
+  return [localRouterStoreProvider];
 }


### PR DESCRIPTION
# Refactors
- Use `Provider[]` return type for provider factories to keep more options open in the future.

BREAKING CHANGE:
- `provideLocalRouterStore` returns `Provider[]` instead of `Provider`
- `provideGlobalRouterStore` returns `Provider[]` instead of `Provider`

No changes required in `providers` arrays, for example the following usage remains the same:
```typescript
@Component({
  // (...)
  providers: [provideLocalRouterStore()],
})
// (...)
```