### PR TITLE
chore: emit ECMAScript-compliant class fields

### DIFF
--- a/packages/router-component-store/tsconfig.json
+++ b/packages/router-component-store/tsconfig.json
@@ -29,7 +29,8 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "useDefineForClassFields": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
# Build
- Emit ECMAScript-compliant class fields: `"useDefineForClassFields": true`. This affects constructor-injected dependencies when used as constructor parameter properties.