### PR TITLE
perf: ignore non-essential router events

### DIFF
--- a/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
@@ -1,5 +1,15 @@
 import { inject, Injectable, Type } from '@angular/core';
-import { Data, Event as RouterEvent, Params, Router } from '@angular/router';
+import {
+  Data,
+  Event as RouterEvent,
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
+  Params,
+  Router,
+  RoutesRecognized,
+} from '@angular/router';
 import { ComponentStore } from '@ngrx/component-store';
 import { map, Observable } from 'rxjs';
 import { MinimalActivatedRouteSnapshot } from '../@ngrx/router-store/minimal-activated-route-state-snapshot';
@@ -72,7 +82,13 @@ export class GlobalRouterStore
     });
 
     this.#updateRouterState(
-      this.#router.events.pipe(
+      this.selectRouterEvents(
+        NavigationStart,
+        RoutesRecognized,
+        NavigationEnd,
+        NavigationCancel,
+        NavigationError
+      ).pipe(
         map(() => this.#serializer.serialize(this.#router.routerState.snapshot))
       )
     );

--- a/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
@@ -3,8 +3,13 @@ import {
   ActivatedRoute,
   Data,
   Event as RouterEvent,
+  NavigationCancel,
+  NavigationEnd,
+  NavigationError,
+  NavigationStart,
   Params,
   Router,
+  RoutesRecognized,
 } from '@angular/router';
 import { ComponentStore } from '@ngrx/component-store';
 import { map, Observable } from 'rxjs';
@@ -71,7 +76,13 @@ export class LocalRouterStore
     });
 
     this.#updateRouterState(
-      this.#router.events.pipe(
+      this.selectRouterEvents(
+        NavigationStart,
+        RoutesRecognized,
+        NavigationEnd,
+        NavigationCancel,
+        NavigationError
+      ).pipe(
         map(() => this.#serializer.serialize(this.#router.routerState.snapshot))
       )
     );


### PR DESCRIPTION
# Performance optimizations
- Ignore non-essential router events when serializing the router state. Only `NavigationStart`, `RoutesRecognized`, `NavigationEnd`, `NavigationCancel`, and `NavigationError` events are essential.