### PR TITLE
chore!: require RxJS ^7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ngrx/router-store": "15.0.0",
     "@ngrx/store": "15.0.0",
     "@nrwl/angular": "15.3.3",
-    "rxjs": "7.4.0",
+    "rxjs": "7.5.7",
     "tslib": "2.4.1",
     "zone.js": "0.12.0"
   },

--- a/packages/router-component-store/package.json
+++ b/packages/router-component-store/package.json
@@ -7,7 +7,7 @@
     "@angular/core": "^15.0.0",
     "@angular/router": "^15.0.0",
     "@ngrx/component-store": "^15.0.0",
-    "rxjs": "^7.4.0"
+    "rxjs": "^7.5.0"
   },
   "dependencies": {
     "tslib": "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9492,12 +9492,12 @@ rxjs@6.6.7, rxjs@^6.5.4, rxjs@^6.5.5:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@7.5.7, rxjs@^7.5.5:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 rxjs@^5.5.6:
   version "5.5.12"
@@ -9505,13 +9505,6 @@ rxjs@^5.5.6:
   integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
   dependencies:
     symbol-observable "1.0.1"
-
-rxjs@^7.5.5:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
-  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
-  dependencies:
-    tslib "^2.1.0"
 
 rxjs@^7.5.6:
   version "7.8.0"
@@ -10468,11 +10461,6 @@ tslib@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils-etc@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
## Build

- Require RxJS ^7.5.0 
  - This is the minimum RxJS 7.x version supported by NgRx ComponentStore 15.x

**BREAKING CHANGES**

Require RxJS ^7.5.0 to match NgRx ComponentStore 15.x requirements.

BEFORE:

```json
{
  "dependencies": {
    "rxjs": "^7.4.0"
  }
}
```

`package.json`

AFTER:

```json
{
  "dependencies": {
    "rxjs": "^7.5.0"
  }
}
```

`package.json`