### PR TITLE
feat!: use strict query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A `RouterStore` service has the following public properties.
 | ------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | `currentRoute$: Observable<MinimalActivatedRouteSnapshot>`                            | Select the current route.                                 |
 | `fragment$: Observable<string \| null>`                                               | Select the current route fragment.                        |
-| `queryParams$: Observable<Params>`                                                    | Select the current route query parameters.                |
+| `queryParams$: Observable<StrictRouteParams>`                                         | Select the current route query parameters.                |
 | `routeData$: Observable<StrictRouteData>`                                             | Select the current route data.                            |
 | `routeParams$: Observable<StrictRouteParams>`                                         | Select the current route parameters.                      |
 | `title$: Observable<string \| undefined>`                                             | Select the resolved route title.                          |
@@ -174,7 +174,7 @@ The `MinimalActivatedRouteSnapshot` interface is used for the observable `Router
 | `fragment: string \| null`                          | The URL fragment shared by all routes.           |
 | `outlet: string`                                    | The outlet name of the route.                    |
 | `params: StrictRouteParams`                         | The matrix parameters scoped to this route.      |
-| `queryParams: Params`                               | The query parameters shared by all routes.       |
+| `queryParams: StrictRouteParams`                    | The query parameters shared by all routes.       |
 | `routeConfig: Route \| null`                        | The configuration used to match this route.      |
 | `title: string \| undefined`                        | The resolved route title.                        |
 | `url: UrlSegment[]`                                 | The URL segments matched by this route.          |
@@ -193,7 +193,7 @@ export type StrictRouteData = {
 
 #### StrictRouteParams
 
-The `StrictRouteParams` interface is used for route parameters in the `MinimalActivatedRouteSnapshot#params` and `RouterStore#routeParams$` properties but not for query parameters. This interface is a strictly typed version of the Angular Router's `Params` type where the `any` member type is replaced with `unknown`.
+The `StrictRouteParams` type is used for route parameters in the `MinimalActivatedRouteSnapshot#params` and `RouterStore#routeParams$` properties and for query parameters in the `MinimalActivatedRouteSnapshot#queryParams` and `RouterStore#queryParams$` properties. It is a strictly typed version of the Angular Router's `Params` type where members are read-only and the `any` member type is replaced with `string | undefined`.
 
 `StrictRouteParams` has the following signature.
 

--- a/packages/router-component-store/src/lib/@ngrx/router-store/minimal-activated-route-state-snapshot.ts
+++ b/packages/router-component-store/src/lib/@ngrx/router-store/minimal-activated-route-state-snapshot.ts
@@ -54,7 +54,7 @@ export interface MinimalActivatedRouteSnapshot {
   /**
    * The query parameters shared by all the routes.
    */
-  readonly queryParams: ActivatedRouteSnapshot['queryParams'];
+  readonly queryParams: StrictRouteParams;
   /**
    * The URL fragment shared by all the routes.
    */

--- a/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
@@ -5,7 +5,6 @@ import {
   NavigationEnd,
   NavigationError,
   NavigationStart,
-  Params,
   Router,
   RoutesRecognized,
 } from '@angular/router';
@@ -53,7 +52,7 @@ export class GlobalRouterStore
     this.#rootRoute$,
     (route) => route.fragment
   );
-  queryParams$: Observable<Params> = this.select(
+  queryParams$: Observable<StrictRouteParams> = this.select(
     this.#rootRoute$,
     (route) => route.queryParams
   );

--- a/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
@@ -7,7 +7,6 @@ import {
   NavigationEnd,
   NavigationError,
   NavigationStart,
-  Params,
   Router,
   RouterStateSnapshot,
   RoutesRecognized,
@@ -45,7 +44,7 @@ export class LocalRouterStore
 
   currentRoute$: Observable<MinimalActivatedRouteSnapshot> = this.#localRoute;
   fragment$: Observable<string | null>;
-  queryParams$: Observable<Params>;
+  queryParams$: Observable<StrictRouteParams>;
   routeData$: Observable<StrictRouteData>;
   routeParams$: Observable<StrictRouteParams>;
   title$: Observable<string | undefined>;

--- a/packages/router-component-store/src/lib/router-store.ts
+++ b/packages/router-component-store/src/lib/router-store.ts
@@ -1,5 +1,5 @@
 import { Injectable, Type } from '@angular/core';
-import { Event as RouterEvent, Params } from '@angular/router';
+import { Event as RouterEvent } from '@angular/router';
 import { Observable } from 'rxjs';
 import { MinimalActivatedRouteSnapshot } from './@ngrx/router-store/minimal-activated-route-state-snapshot';
 import { StrictRouteData } from './strict-route-data';
@@ -46,7 +46,7 @@ export abstract class RouterStore {
   /**
    * Select the current route query parameters.
    */
-  abstract readonly queryParams$: Observable<Params>;
+  abstract readonly queryParams$: Observable<StrictRouteParams>;
   /**
    * Select the current route data.
    */


### PR DESCRIPTION
## Features

- Use strict query parameters

**BREAKING CHANGES**

`RouterStore#queryParams$` and `MinimalActivatedRouteSnapshot#queryParams` use `StrictRouteParams` instead of `Params`. Members are read-only and of type `string | undefined` instead of `any`.

TypeScript will fail to compile application code that has assumed a query parameter type other than `string | undefined`.

BEFORE:

```typescript
// heroes.component.ts
// (...)
import { RouterStore } from "@ngworker/router-component-store";

@Component({
  // (...)
})
export class DashboardComponent {
  #routerStore = inject(RouterStore);

  limit$: Observable<number> = this.#routerStore.queryParams$.pipe(
    map((params) => params["limit"])
  );
}
```

AFTER:

```typescript
// heroes.component.ts
// (...)
import { RouterStore } from "@ngworker/router-component-store";

@Component({
  // (...)
})
export class DashboardComponent {
  #routerStore = inject(RouterStore);

  limit$: Observable<number> = this.#routerStore.queryParams$.pipe(
    map((params) => Number(params["limit"] ?? 10))
  );
}
```