### PR TITLE
feat! use immutable route data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following principles guide the development of Router Component Store.
 
 - The global router store closely matches NgRx Router Store selectors
 - Local router stores closely match `ActivatedRoute` observable properties
-- Router state is serializable
+- Router state is immutable and serializable
 - The API is strictly and strongly typed
 
 ## API

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The `MinimalActivatedRouteSnapshot` interface is used for the observable `Router
 
 #### StrictRouteData
 
-The `StrictRouteData` interface is used for the `MinimalActivatedRouteSnapshot#data$` and `RouterStore#routeData$` properties. This interface is a serializable subset of the Angular Router's `Data` type. In particular, the `symbol` index in the Angular Router's `Data` type is removed. Additionally, the `any` member type is replaced with `unknown` for stricter typing.
+The `StrictRouteData` interface is used for the `MinimalActivatedRouteSnapshot#data` and `RouterStore#routeData$` properties. This interface is a serializable subset of the Angular Router's `Data` type. In particular, the `symbol` index in the Angular Router's `Data` type is removed. Additionally, the `any` member type is replaced with `unknown` for stricter typing.
 
 `StrictRouteData` has the following signature.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The `StrictRouteData` interface is used for the `MinimalActivatedRouteSnapshot#d
 
 ```typescript
 export type StrictRouteData = {
-  [key: string]: unknown;
+  readonly [key: string]: unknown;
 };
 ```
 

--- a/packages/router-component-store/src/lib/strict-route-data.ts
+++ b/packages/router-component-store/src/lib/strict-route-data.ts
@@ -9,4 +9,4 @@ import { StrictNoAny } from './util-types/strict-no-any';
  *
  * Additionally, the `any` member type is converted to `unknown`.
  */
-export type StrictRouteData = StrictNoAny<OmitSymbolIndex<Data>>;
+export type StrictRouteData = Readonly<StrictNoAny<OmitSymbolIndex<Data>>>;


### PR DESCRIPTION
## Features

- Use immutable route data

**BREAKING CHANGES**

`StrictRouteData` members are now read-only.

TypeScript will fail to compile application code that mutates route data data structures.

BEFORE:

```typescript
// heroes.component.ts
// (...)
import { RouterStore } from "@ngworker/router-component-store";

@Component({
  // (...)
})
export class DashboardComponent {
  #routerStore = inject(RouterStore);

  limit$: Observable<number> = this.#routerStore.routeData$.pipe(
    map((data) => {
      data["limit"] = Number(data["limit"])

      return data;
    }),
    map(data => data["limit"])
  );
}
```

AFTER:

```typescript
// heroes.component.ts
// (...)
import { RouterStore } from "@ngworker/router-component-store";

@Component({
  // (...)
})
export class DashboardComponent {
  #routerStore = inject(RouterStore);

  limit$: Observable<number> = this.#routerStore.routeData$.pipe(
    map((data) => Number(data["limit"]))
  );
}
```