### PR TITLE
refactor: replace external `StrictRouteParams` with simple type

### DIFF
--- a/packages/router-component-store/src/lib/@ngrx/router-store/minimal_serializer.ts
+++ b/packages/router-component-store/src/lib/@ngrx/router-store/minimal_serializer.ts
@@ -28,6 +28,7 @@ import {
   Data,
   RouterStateSnapshot,
 } from '@angular/router';
+import { InternalStrictRouteParams } from '../../internal-strict-route-params';
 import { StrictRouteData } from '../../strict-route-data';
 import { MinimalActivatedRouteSnapshot } from './minimal-activated-route-state-snapshot';
 import { MinimalRouterStateSnapshot } from './minimal-router-state-snapshot';
@@ -54,7 +55,7 @@ export class MinimalRouterStateSerializer {
       this.#serializeRouteSnapshot(childRouteSnapshot)
     );
     return {
-      params: routeSnapshot.params,
+      params: routeSnapshot.params as InternalStrictRouteParams,
       data: this.#serializeRouteData(routeSnapshot.data),
       url: routeSnapshot.url,
       outlet: routeSnapshot.outlet,
@@ -71,7 +72,7 @@ export class MinimalRouterStateSerializer {
                 : undefined,
           }
         : null,
-      queryParams: routeSnapshot.queryParams,
+      queryParams: routeSnapshot.queryParams as InternalStrictRouteParams,
       fragment: routeSnapshot.fragment,
       firstChild: children[0],
       children,

--- a/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
@@ -14,9 +14,9 @@ import { MinimalActivatedRouteSnapshot } from '../@ngrx/router-store/minimal-act
 import { MinimalRouterStateSnapshot } from '../@ngrx/router-store/minimal-router-state-snapshot';
 import { MinimalRouterStateSerializer } from '../@ngrx/router-store/minimal_serializer';
 import { filterRouterEvents } from '../filter-router-event.operator';
+import { InternalStrictRouteParams } from '../internal-strict-route-params';
 import { RouterStore } from '../router-store';
 import { StrictRouteData } from '../strict-route-data';
-import { StrictRouteParams } from '../strict-route-params';
 
 interface GlobalRouterState {
   readonly routerState: MinimalRouterStateSnapshot;
@@ -52,7 +52,7 @@ export class GlobalRouterStore
     this.#rootRoute$,
     (route) => route.fragment
   );
-  queryParams$: Observable<StrictRouteParams> = this.select(
+  queryParams$: Observable<InternalStrictRouteParams> = this.select(
     this.#rootRoute$,
     (route) => route.queryParams
   );
@@ -60,7 +60,7 @@ export class GlobalRouterStore
     this.currentRoute$,
     (route) => route.data
   );
-  routeParams$: Observable<StrictRouteParams> = this.select(
+  routeParams$: Observable<InternalStrictRouteParams> = this.select(
     this.currentRoute$,
     (route) => route.params
   );

--- a/packages/router-component-store/src/lib/internal-strict-route-params.ts
+++ b/packages/router-component-store/src/lib/internal-strict-route-params.ts
@@ -1,0 +1,10 @@
+import { Params } from '@angular/router';
+import { StrictNoAny } from './util-types/strict-no-any';
+
+/**
+ * @remarks We use this type to ensure compatibility with {@link Params}.
+ * @internal
+ */
+export type InternalStrictRouteParams = Readonly<
+  StrictNoAny<Params, string | undefined>
+>;

--- a/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
@@ -17,9 +17,9 @@ import { MinimalActivatedRouteSnapshot } from '../@ngrx/router-store/minimal-act
 import { MinimalRouterStateSnapshot } from '../@ngrx/router-store/minimal-router-state-snapshot';
 import { MinimalRouterStateSerializer } from '../@ngrx/router-store/minimal_serializer';
 import { filterRouterEvents } from '../filter-router-event.operator';
+import { InternalStrictRouteParams } from '../internal-strict-route-params';
 import { RouterStore } from '../router-store';
 import { StrictRouteData } from '../strict-route-data';
-import { StrictRouteParams } from '../strict-route-params';
 
 interface LocalRouterState {
   readonly routerState: MinimalRouterStateSnapshot;
@@ -44,9 +44,9 @@ export class LocalRouterStore
 
   currentRoute$: Observable<MinimalActivatedRouteSnapshot> = this.#localRoute;
   fragment$: Observable<string | null>;
-  queryParams$: Observable<StrictRouteParams>;
+  queryParams$: Observable<InternalStrictRouteParams>;
   routeData$: Observable<StrictRouteData>;
-  routeParams$: Observable<StrictRouteParams>;
+  routeParams$: Observable<InternalStrictRouteParams>;
   title$: Observable<string | undefined>;
   url$: Observable<string> = this.select(
     this.#routerState$,

--- a/packages/router-component-store/src/lib/strict-route-params.ts
+++ b/packages/router-component-store/src/lib/strict-route-params.ts
@@ -1,10 +1,7 @@
-import { Params } from '@angular/router';
-import { StrictNoAny } from './util-types/strict-no-any';
-
 /**
  * Strict route {@link Params} with read-only members where the `any` member
  * type is converted to `string | undefined`.
  */
-export type StrictRouteParams = Readonly<
-  StrictNoAny<Params, string | undefined>
->;
+export interface StrictRouteParams {
+  readonly [param: string]: string | undefined;
+}


### PR DESCRIPTION
Closes #327.

### Refactors

- Rename `StrictRouteParams` to `InternalStrictRouteParams` and use it internally to enforce compatibility with Angular's `Params` type
- Replace the exposed `StrictRouteParams` with a simple type