### PR TITLE
refactor: replace external `StrictRouteData` with simple type

### DIFF
--- a/packages/router-component-store/src/lib/@ngrx/router-store/minimal_serializer.ts
+++ b/packages/router-component-store/src/lib/@ngrx/router-store/minimal_serializer.ts
@@ -28,8 +28,8 @@ import {
   Data,
   RouterStateSnapshot,
 } from '@angular/router';
+import { InternalStrictRouteData } from '../../internal-strict-route-data';
 import { InternalStrictRouteParams } from '../../internal-strict-route-params';
-import { StrictRouteData } from '../../strict-route-data';
 import { MinimalActivatedRouteSnapshot } from './minimal-activated-route-state-snapshot';
 import { MinimalRouterStateSnapshot } from './minimal-router-state-snapshot';
 
@@ -44,7 +44,7 @@ export class MinimalRouterStateSerializer {
     };
   }
 
-  #serializeRouteData(routeData: Data): StrictRouteData {
+  #serializeRouteData(routeData: Data): InternalStrictRouteData {
     return Object.fromEntries(Object.entries(routeData));
   }
 
@@ -56,7 +56,9 @@ export class MinimalRouterStateSerializer {
     );
     return {
       params: routeSnapshot.params as InternalStrictRouteParams,
-      data: this.#serializeRouteData(routeSnapshot.data),
+      data: this.#serializeRouteData(
+        routeSnapshot.data
+      ) as InternalStrictRouteData,
       url: routeSnapshot.url,
       outlet: routeSnapshot.outlet,
       title: routeSnapshot.title,

--- a/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
+++ b/packages/router-component-store/src/lib/global-router-store/global-router-store.ts
@@ -14,9 +14,9 @@ import { MinimalActivatedRouteSnapshot } from '../@ngrx/router-store/minimal-act
 import { MinimalRouterStateSnapshot } from '../@ngrx/router-store/minimal-router-state-snapshot';
 import { MinimalRouterStateSerializer } from '../@ngrx/router-store/minimal_serializer';
 import { filterRouterEvents } from '../filter-router-event.operator';
+import { InternalStrictRouteData } from '../internal-strict-route-data';
 import { InternalStrictRouteParams } from '../internal-strict-route-params';
 import { RouterStore } from '../router-store';
-import { StrictRouteData } from '../strict-route-data';
 
 interface GlobalRouterState {
   readonly routerState: MinimalRouterStateSnapshot;
@@ -56,7 +56,7 @@ export class GlobalRouterStore
     this.#rootRoute$,
     (route) => route.queryParams
   );
-  routeData$: Observable<StrictRouteData> = this.select(
+  routeData$: Observable<InternalStrictRouteData> = this.select(
     this.currentRoute$,
     (route) => route.data
   );

--- a/packages/router-component-store/src/lib/internal-strict-route-data.ts
+++ b/packages/router-component-store/src/lib/internal-strict-route-data.ts
@@ -1,0 +1,11 @@
+import { Data } from '@angular/router';
+import { OmitSymbolIndex } from './util-types/omit-symbol-index';
+import { StrictNoAny } from './util-types/strict-no-any';
+
+/**
+ * @remarks We use this type to ensure compatibility with {@link Data}.
+ * @internal
+ */
+export type InternalStrictRouteData = Readonly<
+  StrictNoAny<OmitSymbolIndex<Data>>
+>;

--- a/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
+++ b/packages/router-component-store/src/lib/local-router-store/local-router-store.ts
@@ -17,9 +17,9 @@ import { MinimalActivatedRouteSnapshot } from '../@ngrx/router-store/minimal-act
 import { MinimalRouterStateSnapshot } from '../@ngrx/router-store/minimal-router-state-snapshot';
 import { MinimalRouterStateSerializer } from '../@ngrx/router-store/minimal_serializer';
 import { filterRouterEvents } from '../filter-router-event.operator';
+import { InternalStrictRouteData } from '../internal-strict-route-data';
 import { InternalStrictRouteParams } from '../internal-strict-route-params';
 import { RouterStore } from '../router-store';
-import { StrictRouteData } from '../strict-route-data';
 
 interface LocalRouterState {
   readonly routerState: MinimalRouterStateSnapshot;
@@ -45,7 +45,7 @@ export class LocalRouterStore
   currentRoute$: Observable<MinimalActivatedRouteSnapshot> = this.#localRoute;
   fragment$: Observable<string | null>;
   queryParams$: Observable<InternalStrictRouteParams>;
-  routeData$: Observable<StrictRouteData>;
+  routeData$: Observable<InternalStrictRouteData>;
   routeParams$: Observable<InternalStrictRouteParams>;
   title$: Observable<string | undefined>;
   url$: Observable<string> = this.select(

--- a/packages/router-component-store/src/lib/strict-route-data.ts
+++ b/packages/router-component-store/src/lib/strict-route-data.ts
@@ -1,7 +1,3 @@
-import { Data } from '@angular/router';
-import { OmitSymbolIndex } from './util-types/omit-symbol-index';
-import { StrictNoAny } from './util-types/strict-no-any';
-
 /**
  * Serializable route `Data` without its symbol index, in particular without the
  * `Symbol(RouteTitle)` key as this is an internal value for the Angular
@@ -9,4 +5,6 @@ import { StrictNoAny } from './util-types/strict-no-any';
  *
  * Additionally, the `any` member type is converted to `unknown`.
  */
-export type StrictRouteData = Readonly<StrictNoAny<OmitSymbolIndex<Data>>>;
+export interface StrictRouteData {
+  readonly [key: string]: unknown;
+}


### PR DESCRIPTION
Closes #328.

### Refactors

- Rename `StrictRouteData` to `InternalStrictRouteData` and use it internally to enforce compatibility with Angular's `Data` type
- Replace the exposed `StrictRouteData` with a simple type