### PR TITLE
docs: correct 15.0.0-rc.2 migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ export class ShirtsComponent {
 
   size$: Observable<readonly string[]> = this.#routerStore.queryParams$.pipe(
     map((params) => params['size']),
+    map((size) => size ?? []),
     map((size) => (Array.isArray(size) ? size : [size]))
   );
 }
@@ -93,7 +94,10 @@ export class ShirtsComponent {
 
   size$: Observable<readonly string[]> = this.#routerStore
     .selectQueryParam('size')
-    .pipe(map((size) => (Array.isArray(size) ? size : [size])));
+    .pipe(
+      map((size) => size ?? []),
+      map((size) => (Array.isArray(size) ? size : [size]))
+    );
 }
 ```
 


### PR DESCRIPTION
The *AFTER* code snippets in the migration guide are incorrect as they don't convert an `undefined` query parameter to an empty array (`[]`).