### PR TITLE
ci(github): set default workflow permissions to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ngworker/router-component-store/security/code-scanning/1](https://github.com/ngworker/router-component-store/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file. The best way is to add it at the top level (just below the `name:` key), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows jobs to check out code but not modify repository contents. If any job later requires additional permissions (e.g., to create issues or pull requests), you can override the permissions at the job level. The change should be made at the top of `.github/workflows/ci.yml`, immediately after the `name: CI` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
